### PR TITLE
Add basic Python repository structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,121 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Poetry
+poetry.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
+# OpenHands Playground
 
+A Python project for OpenHands playground.
+
+## Setup
+
+This project uses Poetry for dependency management.
+
+```bash
+# Install Poetry if you don't have it
+curl -sSL https://install.python-poetry.org | python3 -
+
+# Install dependencies
+poetry install
+
+# Activate the virtual environment
+poetry shell
+```
+
+## Development
+
+### Running Tests
+
+```bash
+pytest
+```
+
+### Linting
+
+```bash
+ruff check .
+```
+
+### Type Checking
+
+```bash
+mypy src
+```
+
+## Project Structure
+
+- `src/openhands_playground/`: Source code
+- `test/`: Test files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[tool.poetry]
+name = "openhands_playground"
+version = "0.1.0"
+description = "OpenHands Playground Project"
+authors = ["OpenHands <openhands@all-hands.dev>"]
+readme = "README.md"
+packages = [{include = "openhands_playground", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+ruff = "^0.1.6"
+mypy = "^1.5.1"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+select = ["E", "F", "I", "W", "N", "B", "C4", "UP", "ANN", "D", "PT", "RET", "SIM", "ARG"]
+ignore = ["D203", "D212", "ANN101"]
+
+[tool.ruff.isort]
+known-first-party = ["openhands_playground"]
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+strict_optional = true
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+python_files = "test_*.py"

--- a/src/openhands_playground/__init__.py
+++ b/src/openhands_playground/__init__.py
@@ -1,0 +1,3 @@
+"""OpenHands Playground package."""
+
+__version__ = "0.1.0"

--- a/src/openhands_playground/calculator.py
+++ b/src/openhands_playground/calculator.py
@@ -1,0 +1,77 @@
+"""Simple calculator module."""
+
+from typing import Union
+
+
+def add(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
+    """
+    Add two numbers together.
+
+    Args:
+    ----
+        a: First number
+        b: Second number
+
+    Returns:
+    -------
+        The sum of a and b
+
+    """
+    return a + b
+
+
+def subtract(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
+    """
+    Subtract b from a.
+
+    Args:
+    ----
+        a: First number
+        b: Second number
+
+    Returns:
+    -------
+        The result of a - b
+
+    """
+    return a - b
+
+
+def multiply(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
+    """
+    Multiply two numbers.
+
+    Args:
+    ----
+        a: First number
+        b: Second number
+
+    Returns:
+    -------
+        The product of a and b
+
+    """
+    return a * b
+
+
+def divide(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
+    """
+    Divide a by b.
+
+    Args:
+    ----
+        a: First number
+        b: Second number
+
+    Returns:
+    -------
+        The result of a / b
+
+    Raises:
+    ------
+        ZeroDivisionError: If b is zero
+
+    """
+    if b == 0:
+        raise ZeroDivisionError("Cannot divide by zero")
+    return a / b

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/test/test_calculator.py
+++ b/test/test_calculator.py
@@ -1,0 +1,43 @@
+"""Tests for the calculator module."""
+
+import pytest
+
+from openhands_playground.calculator import add, divide, multiply, subtract
+
+
+def test_add() -> None:
+    """Test the add function."""
+    assert add(1, 2) == 3
+    assert add(1.5, 2.5) == 4.0
+    assert add(-1, 1) == 0
+    assert add(0, 0) == 0
+
+
+def test_subtract() -> None:
+    """Test the subtract function."""
+    assert subtract(3, 2) == 1
+    assert subtract(5.5, 2.5) == 3.0
+    assert subtract(1, 1) == 0
+    assert subtract(0, 5) == -5
+
+
+def test_multiply() -> None:
+    """Test the multiply function."""
+    assert multiply(2, 3) == 6
+    assert multiply(2.5, 2) == 5.0
+    assert multiply(-1, 1) == -1
+    assert multiply(0, 5) == 0
+
+
+def test_divide() -> None:
+    """Test the divide function."""
+    assert divide(6, 3) == 2
+    assert divide(5, 2) == 2.5
+    assert divide(-6, 3) == -2
+    assert divide(0, 5) == 0
+
+
+def test_divide_by_zero() -> None:
+    """Test that dividing by zero raises an error."""
+    with pytest.raises(ZeroDivisionError):
+        divide(5, 0)


### PR DESCRIPTION
This PR adds a basic Python repository structure as requested in issue #1.

## Changes:
- Created src/openhands_playground/ directory structure for source code
- Added Poetry configuration with pyproject.toml
- Set up pytest for testing with test/ directory
- Configured ruff for linting and mypy for type checking
- Added a simple calculator module with tests
- Updated README.md with setup and usage instructions
- Added .gitignore for Python projects

All tests are passing, and the code passes linting and type checking.

Fixes #1

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e23d4721a0dc42278809fbac55d52e9a)